### PR TITLE
Mutable branching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+gat-lending-iterator = "0.1.1"
 serde = "1"
 serde_yaml = "0.9.25"
 tracing = "0.1.37"

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,19 +1,22 @@
+#![allow(dead_code)]
 use std::collections::VecDeque;
 use std::fmt::Write;
 
 use serde_yaml::Value;
 
-use crate::{get, value_name, Candidate, Query, Step};
+use crate::{get, value_name, Candidate, Query, SearchKind, Step};
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Address(pub(crate) Vec<LocationFragment>);
 
 impl std::fmt::Display for Address {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Address[")?;
         for location in &self.0 {
             f.write_char('.')?;
             location.fmt(f)?;
         }
+        f.write_str("]")?;
         Ok(())
     }
 }
@@ -69,222 +72,307 @@ fn matching_addresses(root_node: &Value, query: Query) -> Vec<Address> {
     let mut candidates = VecDeque::from_iter([Candidate {
         starting_point: Address::default(),
         remaining_query: query,
+        search_kind: crate::SearchKind::default(),
     }]);
     let mut addresses = Vec::new();
 
     while let Some(path_to_explore) = candidates.pop_front() {
-        match find_more_addresses(path_to_explore, root_node) {
-            FindAddresses::Hit(address) => addresses.push(address),
-            FindAddresses::Branching(more_candidates) => {
-                candidates.extend(more_candidates);
-            }
-            FindAddresses::Nothing => {}
-        };
+        let found = find_more_addresses(path_to_explore, root_node);
+        if let Some(address) = found.hit {
+            addresses.push(address);
+        }
+        candidates.extend(found.branching);
     }
 
     addresses
 }
 
-pub(crate) enum FindAddresses {
-    Hit(Address),
-    Branching(Vec<Candidate>),
-    Nothing,
+/// The outcome of advancing the the query
+#[derive(Debug)]
+pub(crate) struct FindAddresses {
+    /// there was a path that matched the query at this `Address`
+    pub(crate) hit: Option<Address>,
+    /// multiple viable candidates were found
+    pub(crate) branching: Vec<Candidate>,
+}
+
+impl FindAddresses {
+    fn hit(address: Address) -> FindAddresses {
+        FindAddresses {
+            hit: Some(address),
+            branching: Vec::default(),
+        }
+    }
+
+    fn nothing() -> FindAddresses {
+        FindAddresses {
+            hit: None,
+            branching: Vec::default(),
+        }
+    }
+
+    fn branching(candidates: Vec<Candidate>) -> FindAddresses {
+        FindAddresses {
+            hit: None,
+            branching: candidates,
+        }
+    }
 }
 
 pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresses {
     let current_address = path.starting_point;
+    tracing::info!("Looking at {current_address}");
     // Are we at the end of the query?
     let Some((next_step, remaining_query)) = path.remaining_query.take_step() else {
-        return FindAddresses::Hit(current_address);
+        return FindAddresses::hit(current_address);
     };
+    tracing::info!("The next step to take is {next_step}");
 
     // if not, can we get the node for the current address?
     let Some(node) = get(root, &current_address) else {
-        return FindAddresses::Nothing;
+        return FindAddresses::nothing();
     };
 
-    match (next_step, node) {
-        (Step::Field(f), Value::Mapping(m)) => {
-            if m.get(&f).is_none() {
-                return FindAddresses::Nothing;
-            };
-            find_more_addresses(
-                Candidate {
-                    starting_point: current_address.extend(&f),
-                    remaining_query,
-                },
-                root,
-            )
+    // if our `Candidate` is a recursive, we already know we need to add
+    // all possible fields/indices as additional candidates
+    // and keep searching with the normal query...
+    let mut additional_paths = Vec::new();
+    if let SearchKind::Recursive(recursive_query) = &path.search_kind {
+        if let Some(m) = node.as_mapping() {
+            for (key, _) in m {
+                let field = key.as_str().unwrap().to_string();
+                tracing::info!("Adding a candidate for \"{field}\" in mapping for recursion from {current_address}");
+                additional_paths.push(Candidate {
+                    starting_point: current_address.extend(field),
+                    remaining_query: recursive_query.clone(),
+                    search_kind: path.search_kind.clone(),
+                })
+            }
         }
-        (Step::At(idx), Value::Sequence(s)) => {
-            if s.get(idx).is_none() {
-                return FindAddresses::Nothing;
-            };
-            find_more_addresses(
-                Candidate {
+        if let Some(s) = node.as_sequence() {
+            for idx in 0..s.len() {
+                tracing::info!(
+                    "Adding a candidate for \"{idx}\" in sequence for recursion from {current_address}"
+                );
+                additional_paths.push(Candidate {
                     starting_point: current_address.extend(idx),
-                    remaining_query,
-                },
-                root,
-            )
-        }
-        (Step::Range(r), Value::Sequence(_)) => {
-            let mut additional_paths = Vec::new();
-            for point in r {
-                additional_paths.push(Candidate {
-                    starting_point: current_address.extend(point),
-                    remaining_query: remaining_query.clone(),
-                });
+                    remaining_query: recursive_query.clone(),
+                    search_kind: path.search_kind.clone(),
+                })
             }
-            FindAddresses::Branching(additional_paths)
         }
-        (Step::All, Value::Sequence(sequence)) => {
-            let mut additional_paths = Vec::new();
-            for point in 0..sequence.len() {
-                additional_paths.push(Candidate {
-                    starting_point: current_address.extend(point),
-                    remaining_query: remaining_query.clone(),
-                });
-            }
-            FindAddresses::Branching(additional_paths)
-        }
-        (Step::Filter(field, predicate), s @ Value::String(_)) => {
-            if field != "." {
-                return FindAddresses::Nothing;
-            }
+    }
 
-            if !predicate(s) {
-                return FindAddresses::Nothing;
+    tracing::info!("Checking pairing between {next_step} and {node:?}");
+    let mut next = 'match_block: {
+        match (next_step, node) {
+            (Step::Field(f), Value::Mapping(m)) => {
+                if m.get(&f).is_none() {
+                    FindAddresses::nothing()
+                } else {
+                    find_more_addresses(
+                        Candidate {
+                            starting_point: current_address.extend(&f),
+                            remaining_query,
+                            search_kind: crate::SearchKind::default(),
+                        },
+                        root,
+                    )
+                }
             }
+            (Step::At(idx), Value::Sequence(s)) => {
+                if s.get(idx).is_none() {
+                    FindAddresses::nothing()
+                } else {
+                    find_more_addresses(
+                        Candidate {
+                            starting_point: current_address.extend(idx),
+                            remaining_query,
+                            search_kind: crate::SearchKind::default(),
+                        },
+                        root,
+                    )
+                }
+            }
+            (Step::Range(r), Value::Sequence(_)) => {
+                let mut additional_paths = Vec::new();
+                for point in r {
+                    additional_paths.push(Candidate {
+                        starting_point: current_address.extend(point),
+                        remaining_query: remaining_query.clone(),
+                        search_kind: crate::SearchKind::default(),
+                    });
+                }
+                FindAddresses::branching(additional_paths)
+            }
+            (Step::All, Value::Sequence(sequence)) => {
+                let mut additional_paths = Vec::new();
+                for point in 0..sequence.len() {
+                    additional_paths.push(Candidate {
+                        starting_point: current_address.extend(point),
+                        remaining_query: remaining_query.clone(),
+                        search_kind: crate::SearchKind::default(),
+                    });
+                }
+                FindAddresses::branching(additional_paths)
+            }
+            (Step::Filter(field, predicate), s @ Value::String(_)) => {
+                if field != "." || !predicate(s) {
+                    FindAddresses::nothing()
+                } else {
+                    find_more_addresses(
+                        Candidate {
+                            starting_point: current_address.extend(&field),
+                            remaining_query,
+                            search_kind: crate::SearchKind::default(),
+                        },
+                        root,
+                    )
+                }
+            }
+            (Step::Filter(field, predicate), Value::Sequence(sequence)) => {
+                let mut additional_paths = Vec::new();
+                for (idx, val) in sequence.iter().enumerate() {
+                    let value_to_check = if field == "." {
+                        val
+                    } else {
+                        let Some(value) = val.get(&field) else {
+                            break 'match_block FindAddresses::nothing();
+                        };
+                        value
+                    };
 
-            find_more_addresses(
-                Candidate {
-                    starting_point: current_address.extend(&field),
-                    remaining_query,
-                },
-                root,
-            )
-        }
-        (Step::Filter(field, predicate), Value::Sequence(sequence)) => {
-            let mut additional_paths = Vec::new();
-            for (idx, val) in sequence.iter().enumerate() {
+                    if !predicate(value_to_check) {
+                        continue;
+                    }
+
+                    additional_paths.push(Candidate {
+                        starting_point: current_address.extend(idx),
+                        remaining_query: remaining_query.clone(),
+                        search_kind: crate::SearchKind::default(),
+                    })
+                }
+
+                FindAddresses::branching(additional_paths)
+            }
+            (Step::Filter(field, predicate), val @ Value::Mapping(_)) => {
                 let value_to_check = if field == "." {
                     val
                 } else {
-                    let Some(value) = val.get(&field) else {
-                        return FindAddresses::Nothing;
+                    let Some(value) = val.as_mapping().unwrap().get(&field) else {
+                        break 'match_block FindAddresses::nothing();
                     };
                     value
                 };
 
-                if !predicate(value_to_check) {
-                    continue;
+                if predicate(value_to_check) {
+                    find_more_addresses(
+                        Candidate {
+                            starting_point: current_address.extend(&field),
+                            remaining_query,
+                            search_kind: crate::SearchKind::default(),
+                        },
+                        root,
+                    )
+                } else {
+                    FindAddresses::nothing()
+                }
+            }
+            (Step::SubQuery(field, sub_query), val @ Value::Mapping(_)) => {
+                let value_to_check = if field == "." {
+                    val
+                } else {
+                    let Some(value) = val.as_mapping().unwrap().get(&field) else {
+                        break 'match_block FindAddresses::nothing();
+                    };
+                    value
+                };
+
+                if matching_addresses(value_to_check, sub_query).is_empty() {
+                    FindAddresses::nothing()
+                } else {
+                    find_more_addresses(
+                        Candidate {
+                            starting_point: current_address.extend(&field),
+                            remaining_query,
+                            search_kind: crate::SearchKind::default(),
+                        },
+                        root,
+                    )
+                }
+            }
+            (Step::And(sub_queries), val @ Value::Mapping(_)) => {
+                let value = val;
+                let all_match = sub_queries
+                    .iter()
+                    .all(|q| !matching_addresses(value, q.clone()).is_empty());
+
+                if !all_match {
+                    FindAddresses::nothing()
+                } else {
+                    find_more_addresses(
+                        Candidate {
+                            starting_point: current_address.clone(),
+                            remaining_query,
+                            search_kind: crate::SearchKind::default(),
+                        },
+                        root,
+                    )
+                }
+            }
+            (Step::Or(sub_queries), val @ Value::Mapping(_)) => {
+                let value = val;
+                let any_match = sub_queries
+                    .iter()
+                    .any(|q| !matching_addresses(value, q.clone()).is_empty());
+
+                if !any_match {
+                    FindAddresses::nothing()
+                } else {
+                    find_more_addresses(
+                        Candidate {
+                            starting_point: current_address.clone(),
+                            remaining_query,
+                            search_kind: crate::SearchKind::default(),
+                        },
+                        root,
+                    )
+                }
+            }
+            (Step::Branch(sub_queries), value @ Value::Mapping(_)) => {
+                let mut additional_paths = Vec::new();
+                for sub_query in sub_queries {
+                    for relative_address in matching_addresses(value, sub_query) {
+                        additional_paths.push(Candidate {
+                            starting_point: current_address.append(relative_address),
+                            remaining_query: remaining_query.clone(),
+                            search_kind: crate::SearchKind::default(),
+                        })
+                    }
                 }
 
-                additional_paths.push(Candidate {
-                    starting_point: current_address.extend(idx),
+                FindAddresses::branching(additional_paths)
+            }
+            (Step::Recursive, _) => {
+                // Fall into recursive mode...
+                FindAddresses::branching(vec![Candidate {
+                    starting_point: current_address,
                     remaining_query: remaining_query.clone(),
-                })
+                    search_kind: crate::SearchKind::Recursive(remaining_query.clone()),
+                }])
             }
+            (step, value) => {
+                let step = step.name();
+                let value = value_name(value);
+                tracing::warn!("'{step}' not supported for '{value}'",);
 
-            FindAddresses::Branching(additional_paths)
-        }
-        (Step::Filter(field, predicate), val @ Value::Mapping(_)) => {
-            let value_to_check = if field == "." {
-                val
-            } else {
-                let Some(value) = val.as_mapping().unwrap().get(&field) else {
-                    return FindAddresses::Nothing;
-                };
-                value
-            };
-
-            if !predicate(value_to_check) {
-                return FindAddresses::Nothing;
+                FindAddresses::nothing()
             }
-
-            find_more_addresses(
-                Candidate {
-                    starting_point: current_address.extend(&field),
-                    remaining_query,
-                },
-                root,
-            )
         }
-        (Step::SubQuery(field, sub_query), val @ Value::Mapping(_)) => {
-            let value_to_check = if field == "." {
-                val
-            } else {
-                let Some(value) = val.as_mapping().unwrap().get(&field) else {
-                    return FindAddresses::Nothing;
-                };
-                value
-            };
+    };
 
-            if matching_addresses(value_to_check, sub_query).is_empty() {
-                return FindAddresses::Nothing;
-            }
-            find_more_addresses(
-                Candidate {
-                    starting_point: current_address.extend(&field),
-                    remaining_query,
-                },
-                root,
-            )
-        }
-        (Step::And(sub_queries), val @ Value::Mapping(_)) => {
-            let value = val;
-            let all_match = sub_queries
-                .iter()
-                .all(|q| !matching_addresses(value, q.clone()).is_empty());
+    tracing::info!("This is the outcome of running the step: {next:?}");
 
-            if !all_match {
-                return FindAddresses::Nothing;
-            }
-            find_more_addresses(
-                Candidate {
-                    starting_point: current_address.clone(),
-                    remaining_query,
-                },
-                root,
-            )
-        }
-        (Step::Or(sub_queries), val @ Value::Mapping(_)) => {
-            let value = val;
-            let any_match = sub_queries
-                .iter()
-                .any(|q| !matching_addresses(value, q.clone()).is_empty());
-
-            if !any_match {
-                return FindAddresses::Nothing;
-            }
-            find_more_addresses(
-                Candidate {
-                    starting_point: current_address.clone(),
-                    remaining_query,
-                },
-                root,
-            )
-        }
-        (Step::Branch(sub_queries), value @ Value::Mapping(_)) => {
-            let mut additional_paths = Vec::new();
-            for sub_query in sub_queries {
-                for relative_address in matching_addresses(value, sub_query) {
-                    additional_paths.push(Candidate {
-                        starting_point: current_address.append(relative_address),
-                        remaining_query: remaining_query.clone(),
-                    })
-                }
-            }
-
-            FindAddresses::Branching(additional_paths)
-        }
-        (step, value) => {
-            let step = step.name();
-            let value = value_name(value);
-            tracing::warn!("'{step}' not supported for '{value}'",);
-
-            FindAddresses::Nothing
-        }
-    }
+    next.branching.extend(additional_paths);
+    next
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -121,12 +121,12 @@ impl FindAddresses {
 
 pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresses {
     let current_address = path.starting_point;
-    tracing::info!("Looking at {current_address}");
+    tracing::debug!("Looking at {current_address}");
     // Are we at the end of the query?
     let Some((next_step, remaining_query)) = path.remaining_query.take_step() else {
         return FindAddresses::hit(current_address);
     };
-    tracing::info!("The next step to take is {next_step}");
+    tracing::debug!("The next step to take is {next_step}");
 
     // if not, can we get the node for the current address?
     let Some(node) = get(root, &current_address) else {
@@ -141,7 +141,7 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
         if let Some(m) = node.as_mapping() {
             for (key, _) in m {
                 let field = key.as_str().unwrap().to_string();
-                tracing::info!("Adding a candidate for \"{field}\" in mapping for recursion from {current_address}");
+                tracing::debug!("Adding a candidate for \"{field}\" in mapping for recursion from {current_address}");
                 additional_paths.push(Candidate {
                     starting_point: current_address.extend(field),
                     remaining_query: recursive_query.clone(),
@@ -151,7 +151,7 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
         }
         if let Some(s) = node.as_sequence() {
             for idx in 0..s.len() {
-                tracing::info!(
+                tracing::debug!(
                     "Adding a candidate for \"{idx}\" in sequence for recursion from {current_address}"
                 );
                 additional_paths.push(Candidate {
@@ -163,7 +163,7 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
         }
     }
 
-    tracing::info!("Checking pairing between {next_step} and {node:?}");
+    tracing::debug!("Checking pairing between {next_step} and {node:?}");
     let mut next = 'match_block: {
         match (next_step, node) {
             (Step::Field(f), Value::Mapping(m)) => {
@@ -364,14 +364,14 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
             (step, value) => {
                 let step = step.name();
                 let value = value_name(value);
-                tracing::warn!("'{step}' not supported for '{value}'",);
+                tracing::debug!("'{step}' not supported for '{value}'",);
 
                 FindAddresses::nothing()
             }
         }
     };
 
-    tracing::info!("This is the outcome of running the step: {next:?}");
+    tracing::debug!("This is the outcome of running the step: {next:?}");
 
     next.branching.extend(additional_paths);
     next

--- a/src/iter_address.rs
+++ b/src/iter_address.rs
@@ -23,7 +23,7 @@ pub(crate) fn iter<'input>(root_node: &'input Value, query: Query) -> AddressIte
 }
 
 enum FindingMoreNodes {
-    Hits(Vec<Address>),
+    Hit(Address),
     Branching(Vec<Candidate>),
     Nothing,
 }
@@ -37,7 +37,7 @@ impl<'input> Iterator for AddressIterator<'input> {
 
         while let Some(path_to_explore) = self.candidates.pop_front() {
             match find_more_addresses(path_to_explore, self.root_node) {
-                FindingMoreNodes::Hits(addresses) => self.found_addresses.extend(addresses),
+                FindingMoreNodes::Hit(address) => self.found_addresses.push_back(address),
                 FindingMoreNodes::Branching(more_candidates) => {
                     self.candidates.extend(more_candidates);
                 }
@@ -53,7 +53,7 @@ fn find_more_addresses(path: Candidate, root: &Value) -> FindingMoreNodes {
     let current_address = path.starting_point;
     // Are we at the end of the query?
     let Some((next_step, remaining_query)) = path.remaining_query.take_step() else {
-        return FindingMoreNodes::Hits(vec![current_address]);
+        return FindingMoreNodes::Hit(current_address);
     };
 
     // if not, can we get the node for the current address?

--- a/src/iter_address.rs
+++ b/src/iter_address.rs
@@ -4,14 +4,14 @@ use serde_yaml::Value;
 
 use crate::{get, value_name, Address, Candidate, Query, Step};
 
-struct AddressIterator<'input> {
+pub(crate) struct AddressIterator<'input> {
     candidates: VecDeque<Candidate>,
     // the addresses here have to be relative to the root
     found_addresses: VecDeque<Address>,
     root_node: &'input Value,
 }
 
-fn iter<'input>(root_node: &'input Value, query: Query) -> AddressIterator<'input> {
+pub(crate) fn iter<'input>(root_node: &'input Value, query: Query) -> AddressIterator<'input> {
     AddressIterator {
         candidates: VecDeque::from_iter([Candidate {
             starting_point: Address::default(),

--- a/src/iter_address.rs
+++ b/src/iter_address.rs
@@ -4,14 +4,14 @@ use serde_yaml::Value;
 
 use crate::{get, value_name, Address, Candidate, Query, Step};
 
-pub(crate) struct AddressIterator<'input> {
+struct AddressIterator<'input> {
     candidates: VecDeque<Candidate>,
     // the addresses here have to be relative to the root
     found_addresses: VecDeque<Address>,
     root_node: &'input Value,
 }
 
-pub(crate) fn iter<'input>(root_node: &'input Value, query: Query) -> AddressIterator<'input> {
+fn iter<'input>(root_node: &'input Value, query: Query) -> AddressIterator<'input> {
     AddressIterator {
         candidates: VecDeque::from_iter([Candidate {
             starting_point: Address::default(),

--- a/src/iter_address.rs
+++ b/src/iter_address.rs
@@ -1,0 +1,248 @@
+use std::collections::VecDeque;
+
+use serde_yaml::Value;
+
+use crate::{get, value_name, Address, Candidate, Query, Step};
+
+struct AddressIterator<'input> {
+    candidates: VecDeque<Candidate>,
+    // the addresses here have to be relative to the root
+    found_addresses: VecDeque<Address>,
+    root_node: &'input Value,
+}
+
+fn iter<'input>(root_node: &'input Value, query: Query) -> AddressIterator<'input> {
+    AddressIterator {
+        candidates: VecDeque::from_iter([Candidate {
+            starting_point: Address::default(),
+            remaining_query: query,
+        }]),
+        found_addresses: VecDeque::default(),
+        root_node,
+    }
+}
+
+enum FindingMoreNodes {
+    Hits(Vec<Address>),
+    Branching(Vec<Candidate>),
+    Nothing,
+}
+
+impl<'input> Iterator for AddressIterator<'input> {
+    type Item = Address;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(address) = self.found_addresses.pop_front() {
+            return Some(address);
+        }
+
+        while let Some(path_to_explore) = self.candidates.pop_front() {
+            match find_more_addresses(path_to_explore, self.root_node) {
+                FindingMoreNodes::Hits(addresses) => self.found_addresses.extend(addresses),
+                FindingMoreNodes::Branching(more_candidates) => {
+                    self.candidates.extend(more_candidates);
+                }
+                FindingMoreNodes::Nothing => {}
+            };
+        }
+
+        None
+    }
+}
+
+fn find_more_addresses(path: Candidate, root: &Value) -> FindingMoreNodes {
+    let current_address = path.starting_point;
+    // Are we at the end of the query?
+    let Some((next_step, remaining_query)) = path.remaining_query.take_step() else {
+        return FindingMoreNodes::Hits(vec![current_address]);
+    };
+
+    // if not, can we get the node for the current address?
+    let Some(node) = get(root, &current_address) else {
+        return FindingMoreNodes::Nothing;
+    };
+
+    match (next_step, node) {
+        (Step::Field(f), Value::Mapping(m)) => {
+            if m.get(&f).is_none() {
+                return FindingMoreNodes::Nothing;
+            };
+            find_more_addresses(
+                Candidate {
+                    starting_point: current_address.extend(&f),
+                    remaining_query,
+                },
+                root,
+            )
+        }
+        (Step::At(idx), Value::Sequence(s)) => {
+            if s.get(idx).is_none() {
+                return FindingMoreNodes::Nothing;
+            };
+            find_more_addresses(
+                Candidate {
+                    starting_point: current_address.extend(idx),
+                    remaining_query,
+                },
+                root,
+            )
+        }
+        (Step::Range(r), Value::Sequence(_)) => {
+            let mut additional_paths = Vec::new();
+            for point in r {
+                additional_paths.push(Candidate {
+                    starting_point: current_address.extend(point),
+                    remaining_query: remaining_query.clone(),
+                });
+            }
+            FindingMoreNodes::Branching(additional_paths)
+        }
+        (Step::All, Value::Sequence(sequence)) => {
+            let mut additional_paths = Vec::new();
+            for point in 0..sequence.len() {
+                additional_paths.push(Candidate {
+                    starting_point: current_address.extend(point),
+                    remaining_query: remaining_query.clone(),
+                });
+            }
+            FindingMoreNodes::Branching(additional_paths)
+        }
+        (Step::Filter(field, predicate), s @ Value::String(_)) => {
+            if field != "." {
+                return FindingMoreNodes::Nothing;
+            }
+
+            if !predicate(s) {
+                return FindingMoreNodes::Nothing;
+            }
+
+            find_more_addresses(
+                Candidate {
+                    starting_point: current_address.extend(&field),
+                    remaining_query,
+                },
+                root,
+            )
+        }
+        (Step::Filter(field, predicate), Value::Sequence(sequence)) => {
+            let mut additional_paths = Vec::new();
+            for (idx, val) in sequence.iter().enumerate() {
+                let value_to_check = if field == "." {
+                    val
+                } else {
+                    let Some(value) = val.get(&field) else {
+                        return FindingMoreNodes::Nothing;
+                    };
+                    value
+                };
+
+                if !predicate(value_to_check) {
+                    continue;
+                }
+
+                additional_paths.push(Candidate {
+                    starting_point: current_address.extend(idx),
+                    remaining_query: remaining_query.clone(),
+                })
+            }
+
+            FindingMoreNodes::Branching(additional_paths)
+        }
+        (Step::Filter(field, predicate), val @ Value::Mapping(_)) => {
+            let value_to_check = if field == "." {
+                val
+            } else {
+                let Some(value) = val.as_mapping().unwrap().get(&field) else {
+                    return FindingMoreNodes::Nothing;
+                };
+                value
+            };
+
+            if !predicate(value_to_check) {
+                return FindingMoreNodes::Nothing;
+            }
+
+            find_more_addresses(
+                Candidate {
+                    starting_point: current_address.extend(&field),
+                    remaining_query,
+                },
+                root,
+            )
+        }
+        (Step::SubQuery(field, sub_query), val @ Value::Mapping(_)) => {
+            let value_to_check = if field == "." {
+                val
+            } else {
+                let Some(value) = val.as_mapping().unwrap().get(&field) else {
+                    return FindingMoreNodes::Nothing;
+                };
+                value
+            };
+
+            if iter(value_to_check, sub_query).next().is_none() {
+                return FindingMoreNodes::Nothing;
+            }
+            find_more_addresses(
+                Candidate {
+                    starting_point: current_address.extend(&field),
+                    remaining_query,
+                },
+                root,
+            )
+        }
+        (Step::And(sub_queries), val @ Value::Mapping(_)) => {
+            let value = val;
+            let all_match = sub_queries
+                .iter()
+                .all(|q| iter(value, q.clone()).next().is_some());
+
+            if !all_match {
+                return FindingMoreNodes::Nothing;
+            }
+            find_more_addresses(
+                Candidate {
+                    starting_point: current_address.clone(),
+                    remaining_query,
+                },
+                root,
+            )
+        }
+        (Step::Or(sub_queries), val @ Value::Mapping(_)) => {
+            let value = val;
+            let any_match = sub_queries
+                .iter()
+                .any(|q| iter(value, q.clone()).next().is_some());
+
+            if !any_match {
+                return FindingMoreNodes::Nothing;
+            }
+            find_more_addresses(
+                Candidate {
+                    starting_point: current_address.clone(),
+                    remaining_query,
+                },
+                root,
+            )
+        }
+        (Step::Branch(sub_queries), value @ Value::Mapping(_)) => {
+            let mut additional_paths = Vec::new();
+            for sub_query in sub_queries {
+                for relative_address in iter(value, sub_query) {
+                    additional_paths.push(Candidate {
+                        starting_point: current_address.append(relative_address),
+                        remaining_query: remaining_query.clone(),
+                    })
+                }
+            }
+
+            FindingMoreNodes::Branching(additional_paths)
+        }
+        (step, value) => {
+            let step = step.name();
+            let value = value_name(value);
+            tracing::warn!("'{step}' not supported for '{value}'",);
+
+            FindingMoreNodes::Nothing
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,15 +235,13 @@ impl<'input> Iterator for ManyResults<'input> {
 }
 
 fn get_mut<'a>(node: &'a mut Value, adr: &Address) -> Option<&'a mut Value> {
-    use LocationFragment::*;
-
     let mut current_node = Some(node);
     for fragment in &adr.0 {
         let actual_node = current_node?;
         match fragment {
-            Field(f) if f == "." => current_node = Some(actual_node),
-            Field(f) => current_node = actual_node.get_mut(f),
-            Index(i) => current_node = actual_node.get_mut(i),
+            LocationFragment::Field(f) if f == "." => current_node = Some(actual_node),
+            LocationFragment::Field(f) => current_node = actual_node.get_mut(f),
+            LocationFragment::Index(i) => current_node = actual_node.get_mut(i),
         }
     }
 
@@ -251,15 +249,13 @@ fn get_mut<'a>(node: &'a mut Value, adr: &Address) -> Option<&'a mut Value> {
 }
 
 fn get<'a>(node: &'a Value, adr: &Address) -> Option<&'a Value> {
-    use LocationFragment::*;
-
     let mut current_node = Some(node);
     for fragment in &adr.0 {
         let actual_node = current_node?;
         match fragment {
-            Field(f) if f == "." => current_node = Some(actual_node),
-            Field(f) => current_node = actual_node.get(f),
-            Index(i) => current_node = actual_node.get(i),
+            LocationFragment::Field(f) if f == "." => current_node = Some(actual_node),
+            LocationFragment::Field(f) => current_node = actual_node.get(f),
+            LocationFragment::Index(i) => current_node = actual_node.get(i),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,12 +272,10 @@ fn get_mut<'a>(node: &'a mut Value, adr: &Address) -> Option<&'a mut Value> {
 
     let mut current_node = Some(node);
     for fragment in &adr.0 {
-        if current_node.is_none() {
-            return None;
-        }
+        let actual_node = current_node?;
         match fragment {
-            Field(f) => current_node = current_node.take().and_then(|node| node.get_mut(f)),
-            Index(i) => current_node = current_node.take().and_then(|node| node.get_mut(i)),
+            Field(f) => current_node = actual_node.get_mut(f),
+            Index(i) => current_node = actual_node.get_mut(i),
         }
     }
 
@@ -289,12 +287,10 @@ fn get<'a>(node: &'a Value, adr: &Address) -> Option<&'a Value> {
 
     let mut current_node = Some(node);
     for fragment in &adr.0 {
-        if current_node.is_none() {
-            return None;
-        }
+        let actual_node = current_node?;
         match fragment {
-            Field(f) => current_node = current_node.take().and_then(|node| node.get(f)),
-            Index(i) => current_node = current_node.take().and_then(|node| node.get(i)),
+            Field(f) => current_node = actual_node.get(f),
+            Index(i) => current_node = actual_node.get(i),
         }
     }
 
@@ -516,7 +512,7 @@ fn find_more_nodes(path: Candidate, root: &Value) -> FindingMoreNodes {
         (Step::Branch(sub_queries), value @ Value::Mapping(_)) => {
             let mut additional_paths = Vec::new();
             for sub_query in sub_queries {
-                for relative_address in relevant_addresses(&value, sub_query) {
+                for relative_address in relevant_addresses(value, sub_query) {
                     additional_paths.push(Candidate {
                         starting_point: current_address.append(relative_address),
                         remaining_query: remaining_query.clone(),
@@ -754,15 +750,14 @@ pub fn navigate_iter(input: &Value, query: Query) -> ManyResults<'_> {
 }
 
 pub fn navigate_iter_mut(input: &mut Value, query: Query) -> ManyMutResults<'_> {
-    let results = ManyMutResults {
+    ManyMutResults {
         root_node: input,
         candidates: VecDeque::from_iter([Candidate {
             starting_point: Address::default(),
             remaining_query: query,
         }]),
         found_addresses: VecDeque::default(),
-    };
-    results
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::iter_address::find_more_addresses;
-use iter_address::FindingMoreNodes;
+use iter_address::FindAddresses;
 use serde::de::DeserializeOwned;
 use serde_yaml::Value;
 
@@ -217,16 +217,16 @@ impl<'input> Iterator for ManyResults<'input> {
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(path_to_explore) = self.candidates.pop_front() {
             match find_more_addresses(path_to_explore, self.root_node) {
-                FindingMoreNodes::Hit(address) => {
+                FindAddresses::Hit(address) => {
                     let node = get(self.root_node, &address);
                     if node.is_some() {
                         return node;
                     }
                 }
-                FindingMoreNodes::Branching(more_candidates) => {
+                FindAddresses::Branching(more_candidates) => {
                     self.candidates.extend(more_candidates);
                 }
-                FindingMoreNodes::Nothing => {}
+                FindAddresses::Nothing => {}
             };
         }
 
@@ -339,13 +339,13 @@ impl<'input> Iterator for ManyMutResults<'input> {
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(path_to_explore) = self.candidates.pop_front() {
             match find_more_addresses(path_to_explore, self.root_node) {
-                FindingMoreNodes::Hit(address) => {
+                FindAddresses::Hit(address) => {
                     self.found_addresses.push_back(address);
                 }
-                FindingMoreNodes::Branching(more_candidates) => {
+                FindAddresses::Branching(more_candidates) => {
                     self.candidates.extend(more_candidates);
                 }
-                FindingMoreNodes::Nothing => {}
+                FindAddresses::Nothing => {}
             };
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use serde::de::DeserializeOwned;
 use serde_yaml::Value;
 
+mod iter_address;
+
 macro_rules! step {
     ("*") => {
         Step::All
@@ -254,13 +256,13 @@ impl From<usize> for LocationFragment {
 }
 
 impl Address {
-    fn extend(&self, fragment: impl Into<LocationFragment>) -> Address {
+    pub(crate) fn extend(&self, fragment: impl Into<LocationFragment>) -> Address {
         let mut this = self.clone();
         this.0.push(fragment.into());
         this
     }
 
-    fn append(&self, mut relative_address: Address) -> Address {
+    pub(crate) fn append(&self, mut relative_address: Address) -> Address {
         let mut this = self.clone();
         this.0.append(&mut relative_address.0);
         this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 #![allow(unused_macros)]
 use std::collections::VecDeque;
-use std::fmt::Write;
 use std::ops::Range;
 use std::sync::Arc;
 
-use crate::iter_address::find_more_addresses;
-use iter_address::FindAddresses;
+use address::{find_more_addresses, Address, FindAddresses};
 use serde::de::DeserializeOwned;
 use serde_yaml::Value;
 
-mod iter_address;
+use crate::address::LocationFragment;
+
+mod address;
 
 macro_rules! step {
     ("*") => {
@@ -231,66 +231,6 @@ impl<'input> Iterator for ManyResults<'input> {
         }
 
         None
-    }
-}
-
-#[derive(Clone, Default, Debug)]
-struct Address(Vec<LocationFragment>);
-
-impl std::fmt::Display for Address {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for location in &self.0 {
-            f.write_char('.')?;
-            location.fmt(f)?;
-        }
-        Ok(())
-    }
-}
-
-#[derive(Clone, Debug)]
-enum LocationFragment {
-    Field(String),
-    Index(usize),
-}
-
-impl std::fmt::Display for LocationFragment {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LocationFragment::Field(s) => f.write_str(s),
-            LocationFragment::Index(i) => f.write_str(i.to_string().as_str()),
-        }
-    }
-}
-
-impl From<&String> for LocationFragment {
-    fn from(value: &String) -> Self {
-        Self::Field(value.clone())
-    }
-}
-
-impl From<String> for LocationFragment {
-    fn from(value: String) -> Self {
-        Self::Field(value)
-    }
-}
-
-impl From<usize> for LocationFragment {
-    fn from(value: usize) -> Self {
-        Self::Index(value)
-    }
-}
-
-impl Address {
-    pub(crate) fn extend(&self, fragment: impl Into<LocationFragment>) -> Address {
-        let mut this = self.clone();
-        this.0.push(fragment.into());
-        this
-    }
-
-    pub(crate) fn append(&self, mut relative_address: Address) -> Address {
-        let mut this = self.clone();
-        this.0.append(&mut relative_address.0);
-        this
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,7 @@ impl<'input> Iterator for ManyMutResults<'input> {
             match find_more_addresses(path_to_explore, self.root_node) {
                 FindAddresses::Hit(address) => {
                     self.found_addresses.push_back(address);
+                    break;
                 }
                 FindAddresses::Branching(more_candidates) => {
                     self.candidates.extend(more_candidates);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use serde_yaml::Value;
 use crate::address::LocationFragment;
 
 mod address;
+pub use gat_lending_iterator::LendingIterator;
 
 #[macro_export]
 macro_rules! step {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,64 +11,71 @@ use crate::address::LocationFragment;
 
 mod address;
 
+#[macro_export]
 macro_rules! step {
     ("*") => {
-        Step::All
+        $crate::Step::All
     };
     ($a:expr) => {
-        Step::from($a)
+        $crate::Step::from($a)
     };
 }
 
+#[macro_export]
 macro_rules! query {
     ($($a:expr $(,)?)+) => {{
-        let mut the_query = Query::default();
+        let mut the_query = $crate::Query::default();
         $(
-            the_query.steps.push(step!($a));
+            the_query.steps.push($crate::step!($a));
         )+
         the_query
     }};
 }
 
+#[macro_export]
 macro_rules! r#where {
     ($field:literal => $body:expr) => {{
-        Step::filter($field, $body)
+        $crate::Step::filter($field, $body)
     }};
 }
 
+#[macro_export]
 macro_rules! sub {
     ($field:literal => $sub_query:expr) => {{
-        Step::sub_query($field, $sub_query)
+        $crate::Step::sub_query($field, $sub_query)
     }};
 }
 
+#[macro_export]
 macro_rules! and {
     ($($a:expr $(,)?)+) => {{
-        let mut arms: Vec<Query> = Vec::new();
+        let mut arms: Vec<$crate::Query> = Vec::new();
         $(
             arms.push($a);
         )+
-        Step::And(arms)
+        $crate::Step::And(arms)
     }};
 }
 
+#[macro_export]
 macro_rules! or {
     ($($a:expr $(,)?)+) => {{
-        let mut arms: Vec<Query> = Vec::new();
+        let mut arms: Vec<$crate::Query> = Vec::new();
         $(
             arms.push($a);
         )+
-        Step::Or(arms)
+        $crate::Step::Or(arms)
     }};
 }
 
+#[macro_export]
 macro_rules! branch {
     ($($a:expr $(,)?)+) => {{
-        let mut arms: Vec<Query> = Vec::new();
+        let mut arms: Vec<$crate::Query> = Vec::new();
         $(
             arms.push($a.into());
         )+
-        Step::Branch(arms)
+        $crate::Step::Branch(arms)
     }};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,17 +243,17 @@ impl<'input> Iterator for ManyResults<'input> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(path_to_explore) = self.candidates.pop_front() {
-            tracing::info!(
+            tracing::debug!(
                 "Next candidate to explore: '{}' with query: '{:?}'",
                 path_to_explore.starting_point,
                 path_to_explore.remaining_query,
             );
             let found = find_more_addresses(path_to_explore, self.root_node);
-            tracing::info!("Found something...");
+            tracing::debug!("Found something...");
             self.candidates.extend(found.branching);
 
             if let Some(address) = found.hit {
-                tracing::info!("We got a hit: {address}");
+                tracing::debug!("We got a hit: {address}");
                 let node = get(self.root_node, &address);
                 if node.is_some() {
                     return node;
@@ -307,12 +307,12 @@ impl<'input> gat_lending_iterator::LendingIterator for ManyMutResults<'input> {
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         while let Some(path_to_explore) = self.candidates.pop_front() {
-            tracing::info!("Looking at {}", path_to_explore.starting_point);
+            tracing::debug!("Looking at {}", path_to_explore.starting_point);
             let found = find_more_addresses(path_to_explore, self.root_node);
             self.candidates.extend(found.branching);
 
             if let Some(address) = found.hit {
-                tracing::info!("We got a hit: {address}");
+                tracing::debug!("We got a hit: {address}");
                 self.found_addresses.push_back(address);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use std::ops::Range;
 use std::sync::Arc;
 
+use iter_address::AddressIterator;
 use serde::de::DeserializeOwned;
 use serde_yaml::Value;
 
@@ -300,31 +301,20 @@ fn get<'a>(node: &'a Value, adr: &Address) -> Option<&'a Value> {
 }
 
 pub struct ManyMutResults<'input> {
-    candidates: VecDeque<Candidate>,
-    // the addresses here have to be relative to the root
-    found_addresses: VecDeque<Address>,
     root_node: &'input mut Value,
+    addresses: AddressIterator<'input>,
 }
 
 impl<'input> Iterator for ManyMutResults<'input> {
     type Item = &'input mut Value;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(path_to_explore) = self.candidates.pop_front() {
-            match find_more_nodes(path_to_explore, self.root_node) {
-                FindingMoreNodes::Hits(addresses) => self.found_addresses.extend(addresses),
-                FindingMoreNodes::Branching(more_candidates) => {
-                    self.candidates.extend(more_candidates);
-                }
-                FindingMoreNodes::Nothing => {}
-            };
-        }
-
-        while let Some(address) = self.found_addresses.pop_front() {
-            if let Some(found_node) = get_mut(self.root_node, &address) {
-                // Highly suspicious code right tgere!
-                return unsafe { Some(&mut *(found_node as *mut Value)) };
-            }
+        let Some(address) = self.addresses.next() else {
+            return None;
+        };
+        if let Some(found_node) = get_mut(self.root_node, &address) {
+            // Highly suspicious code right tgere!
+            return unsafe { Some(&mut *(found_node as *mut Value)) };
         }
         None
     }
@@ -754,11 +744,7 @@ pub fn navigate_iter(input: &Value, query: Query) -> ManyResults<'_> {
 pub fn navigate_iter_mut(input: &mut Value, query: Query) -> ManyMutResults<'_> {
     ManyMutResults {
         root_node: input,
-        candidates: VecDeque::from_iter([Candidate {
-            starting_point: Address::default(),
-            remaining_query: query,
-        }]),
-        found_addresses: VecDeque::default(),
+        addresses: iter_address::iter(input, query.clone()),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,11 @@ impl<'input> Iterator for ManyMutResults<'input> {
 
         while let Some(address) = self.found_addresses.pop_front() {
             if let Some(found_node) = get_mut(self.root_node, &address) {
-                // Highly suspicious code right tgere!
+                // SAFETY:
+                // I think this should be safe because:
+                // * ManyMutResults iter is given an exclusive reference to the underlying serde_yaml::Value
+                // * This is the only reference being handed out. Internally we keep track of possible `Address`
+                //   inside the YAML which then get checked before handing out a reference.
                 return unsafe { Some(&mut *(found_node as *mut Value)) };
             }
         }


### PR DESCRIPTION
The mutable iterator builds on the idea that it internally collectors "addresses" that represent a path in the YAML/`serde_yaml::Value`. This means we don't hold on to references (`&serde_yaml::Value`) as we used to in the non-mut iterator.

It also means that both iterators can share the same infrastructure for finding a path in the YAML.