### PR TITLE
Added context to yielded items

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -121,12 +121,12 @@ impl FindAddresses {
 
 pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresses {
     let current_address = path.starting_point;
-    tracing::debug!("Looking at {current_address}");
+    tracing::trace!("Looking at {current_address}");
     // Are we at the end of the query?
     let Some((next_step, remaining_query)) = path.remaining_query.take_step() else {
         return FindAddresses::hit(current_address);
     };
-    tracing::debug!("The next step to take is {next_step}");
+    tracing::trace!("The next step to take is {next_step}");
 
     // if not, can we get the node for the current address?
     let Some(node) = get(root, &current_address) else {
@@ -141,7 +141,7 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
         if let Some(m) = node.as_mapping() {
             for (key, _) in m {
                 let field = key.as_str().unwrap().to_string();
-                tracing::debug!("Adding a candidate for \"{field}\" in mapping for recursion from {current_address}");
+                tracing::trace!("Adding a candidate for \"{field}\" in mapping for recursion from {current_address}");
                 additional_paths.push(Candidate {
                     starting_point: current_address.extend(field),
                     remaining_query: recursive_query.clone(),
@@ -151,7 +151,7 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
         }
         if let Some(s) = node.as_sequence() {
             for idx in 0..s.len() {
-                tracing::debug!(
+                tracing::trace!(
                     "Adding a candidate for \"{idx}\" in sequence for recursion from {current_address}"
                 );
                 additional_paths.push(Candidate {
@@ -163,7 +163,7 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
         }
     }
 
-    tracing::debug!("Checking pairing between {next_step} and {node:?}");
+    tracing::trace!("Checking pairing between {next_step} and {node:?}");
     let mut next = 'match_block: {
         match (next_step, node) {
             (Step::Field(f), Value::Mapping(m)) => {
@@ -364,14 +364,14 @@ pub(crate) fn find_more_addresses(path: Candidate, root: &Value) -> FindAddresse
             (step, value) => {
                 let step = step.name();
                 let value = value_name(value);
-                tracing::debug!("'{step}' not supported for '{value}'",);
+                tracing::trace!("'{step}' not supported for '{value}'",);
 
                 FindAddresses::nothing()
             }
         }
     };
 
-    tracing::debug!("This is the outcome of running the step: {next:?}");
+    tracing::trace!("This is the outcome of running the step: {next:?}");
 
     next.branching.extend(additional_paths);
     next

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ macro_rules! or {
 #[macro_export]
 macro_rules! branch {
     ($($a:expr $(,)?)+) => {{
+        #[allow(clippy::vec_init_then_push)]
         let mut arms: Vec<$crate::Query> = Vec::new();
         $(
             arms.push($a.into());
@@ -258,13 +259,13 @@ impl Path {
         for s in &self.0 {
             match s {
                 LocationFragment::Field(f) => {
-                    buf.push_str(".");
-                    buf.push_str(&f);
+                    buf.push('.');
+                    buf.push_str(f);
                 }
                 LocationFragment::Index(at) => {
-                    buf.push_str("[");
+                    buf.push('[');
                     buf.push_str(&at.to_string());
-                    buf.push_str("]");
+                    buf.push(']');
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,17 +244,17 @@ impl<'input> Iterator for ManyResults<'input> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(path_to_explore) = self.candidates.pop_front() {
-            tracing::debug!(
+            tracing::trace!(
                 "Next candidate to explore: '{}' with query: '{:?}'",
                 path_to_explore.starting_point,
                 path_to_explore.remaining_query,
             );
             let found = find_more_addresses(path_to_explore, self.root_node);
-            tracing::debug!("Found something...");
+            tracing::trace!("Found something...");
             self.candidates.extend(found.branching);
 
             if let Some(address) = found.hit {
-                tracing::debug!("We got a hit: {address}");
+                tracing::trace!("We got a hit: {address}");
                 let node = get(self.root_node, &address);
                 if node.is_some() {
                     return node;
@@ -308,12 +308,12 @@ impl<'input> gat_lending_iterator::LendingIterator for ManyMutResults<'input> {
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         while let Some(path_to_explore) = self.candidates.pop_front() {
-            tracing::debug!("Looking at {}", path_to_explore.starting_point);
+            tracing::trace!("Looking at {}", path_to_explore.starting_point);
             let found = find_more_addresses(path_to_explore, self.root_node);
             self.candidates.extend(found.branching);
 
             if let Some(address) = found.hit {
-                tracing::debug!("We got a hit: {address}");
+                tracing::trace!("We got a hit: {address}");
                 self.found_addresses.push_back(address);
             }
         }


### PR DESCRIPTION
This allows users to interrogate the path to the value, e.g. `.people[2].sport[0]`.